### PR TITLE
Restrict access to articles controller

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -47,12 +47,17 @@ class ArticlesController < ApplicationController
   end
 
   def destroy
-    if @article.destroy
-      flash[:notice] = 'Article has been deleted'
-      redirect_to articles_path
+    unless @article.user == current_user
+      flash[:alert] = 'You can only delete your own article.'
+      redirect_to root_path
     else
-      flash[:danger] = 'Article has not been deleted'
-      render :show
+      if @article.destroy
+        flash[:notice] = 'Article has been deleted'
+        redirect_to articles_path
+      else
+        flash[:danger] = 'Article has not been deleted'
+        render :show
+      end
     end
   end
 

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,4 +1,5 @@
 class ArticlesController < ApplicationController
+  before_action :authenticate_user!, except: [:index, :show]
   before_action :set_article, only: [:show, :edit, :update, :destroy]
 
   def index
@@ -9,6 +10,10 @@ class ArticlesController < ApplicationController
   end
 
   def edit
+    unless @article.user == current_user
+      flash[:alert] = 'You can only edit your own article.'
+      redirect_to root_path
+    end
   end
 
   def new
@@ -27,12 +32,17 @@ class ArticlesController < ApplicationController
   end
 
   def update
-    if @article.update(article_params)
-      flash[:notice] = 'Article has been updated'
-      redirect_to @article
+    unless @article.user == current_user
+      flash[:alert] = 'You can only edit your own article.'
+      redirect_to root_path
     else
-      flash.now[:danger] = 'Article has not been updated'
-      render :edit
+      if @article.update(article_params)
+        flash[:notice] = 'Article has been updated'
+        redirect_to @article
+      else
+        flash.now[:danger] = 'Article has not been updated'
+        render :edit
+      end
     end
   end
 

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -1,4 +1,6 @@
-<%= link_to 'New Article', new_article_path, class: 'btn btn-default btn-lg', id: 'new-article-btn' %>
+<% if user_signed_in? %>
+  <%= link_to 'New Article', new_article_path, class: 'btn btn-default btn-lg', id: 'new-article-btn' %>
+<% end %>
 
 <% if @articles.empty? %>
   <h1 id='no-articles'>No Articles Created</h1>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -11,9 +11,11 @@
     <%= @article.body %>
   </div>
 
-  <div class="edit-delete">
-    <%= link_to 'Edit Article', edit_article_path(@article), class: 'btn btn-primary btn-lg btn-space' %>
+  <% if user_signed_in? && current_user == @article.user %>
+    <div class="edit-delete">
+      <%= link_to 'Edit Article', edit_article_path(@article), class: 'btn btn-primary btn-lg btn-space' %>
 
-    <%= link_to 'Delete Article', article_path(@article), method: :delete, data: { confirm: 'Are you sure you want to delete article?' }, class: 'btn btn-primary btn-lg btn-space' %>
-  </div>
+      <%= link_to 'Delete Article', article_path(@article), method: :delete, data: { confirm: 'Are you sure you want to delete article?' }, class: 'btn btn-primary btn-lg btn-space' %>
+    </div>
+  <% end %>
 </article>

--- a/spec/features/listing_articles_spec.rb
+++ b/spec/features/listing_articles_spec.rb
@@ -2,13 +2,12 @@ require 'rails_helper'
 
 RSpec.feature "Listing Articles" do
   before do
-    john = User.create(email: 'john@example.com', password: 'password')
-    login_as john
-    @article1 = Article.create(title: 'The first article', body: 'Body of first article', user: john)
-    @article2 = Article.create(title: 'The second article', body: 'Body of second article', user: john)
+    @john = User.create(email: 'john@example.com', password: 'password')
+    @article1 = Article.create(title: 'The first article', body: 'Body of first article', user: @john)
+    @article2 = Article.create(title: 'The second article', body: 'Body of second article', user: @john)
   end
 
-  scenario 'A user lists all articles' do
+  scenario 'with articles created and user not signed in' do
     visit '/'
 
     expect(page).to have_content(@article1.title)
@@ -17,6 +16,21 @@ RSpec.feature "Listing Articles" do
     expect(page).to have_content(@article2.body)
     expect(page).to have_link(@article1.title)
     expect(page).to have_link(@article2.title)
+    expect(page).not_to have_link 'New Article'
+  end
+
+  scenario 'with articles created and user signed in' do
+    login_as @john
+
+    visit '/'
+
+    expect(page).to have_content(@article1.title)
+    expect(page).to have_content(@article1.body)
+    expect(page).to have_content(@article2.title)
+    expect(page).to have_content(@article2.body)
+    expect(page).to have_link(@article1.title)
+    expect(page).to have_link(@article2.title)
+    expect(page).to have_link 'New Article'
   end
 
   scenario 'A user has no articles' do

--- a/spec/features/show_article_spec.rb
+++ b/spec/features/show_article_spec.rb
@@ -3,12 +3,12 @@ require 'rails_helper'
 RSpec.feature "Show Article" do
 
   before do
-    john = User.create(email: 'john@example.com', password: 'password')
-    login_as john
-    @article = Article.create(title: 'Article title', body: 'Article body', user: john)
+    @john = User.create(email: 'john@example.com', password: 'password')
+    @fred = User.create(email: 'fred@example.com', password: 'password')
+    @article = Article.create(title: 'Article title', body: 'Article body', user: @john)
   end
 
-  scenario 'A user shows an article' do
+  scenario 'to non-signed in user hide the edit and delete buttons' do
     visit '/'
 
     click_link @article.title
@@ -16,5 +16,20 @@ RSpec.feature "Show Article" do
     expect(page).to have_content @article.title
     expect(page).to have_content @article.body
     expect(current_path).to eq article_path(@article)
+    expect(page).not_to have_link 'Edit Article'
+    expect(page).not_to have_link 'Delete Article'
+  end
+
+  scenario 'to non-owner user hide the edit and delete buttons' do
+    login_as @fred
+    visit '/'
+
+    click_link @article.title
+
+    expect(page).to have_content @article.title
+    expect(page).to have_content @article.body
+    expect(current_path).to eq article_path(@article)
+    expect(page).not_to have_link 'Edit Article'
+    expect(page).not_to have_link 'Delete Article'
   end
 end

--- a/spec/features/show_article_spec.rb
+++ b/spec/features/show_article_spec.rb
@@ -32,4 +32,17 @@ RSpec.feature "Show Article" do
     expect(page).not_to have_link 'Edit Article'
     expect(page).not_to have_link 'Delete Article'
   end
+
+  scenario 'to owner user shows the edit and delete buttons' do
+    login_as @john
+    visit '/'
+
+    click_link @article.title
+
+    expect(page).to have_content @article.title
+    expect(page).to have_content @article.body
+    expect(current_path).to eq article_path(@article)
+    expect(page).to have_link 'Edit Article'
+    expect(page).to have_link 'Delete Article'
+  end
 end

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -62,4 +62,41 @@ RSpec.describe "Articles", type: :request do
         end
       end
     end
+
+    describe 'DELETE /articles/:id' do
+      context 'with non-signed in user' do
+        before { delete "/articles/#{@article.id}" }
+
+        it 'redirects to the sign in page' do
+          expect(response.status).to eq 302
+          flash_message = "You need to sign in or sign up before continuing."
+          expect(flash[:alert]).to eq flash_message
+        end
+      end
+
+      context 'with signed in user who is non owner' do
+        before do
+          login_as @fred
+          delete "/articles/#{@article.id}"
+        end
+
+        it 'redirects to the home page' do
+          expect(response.status).to eq 302
+          flash_message = 'You can only delete your own article.'
+          expect(flash[:alert]).to eq flash_message
+        end
+      end
+
+      context 'with signed in user as owner successful delete' do
+        before do
+          login_as @john
+          delete "/articles/#{@article.id}"
+        end
+
+        it 'successfully edits article' do
+          expect(response.status).to eq 302
+          expect(flash[:notice]).to eq 'Article has been deleted'
+        end
+      end
+    end
 end

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -2,9 +2,47 @@ require 'rails_helper'
 
 RSpec.describe "Articles", type: :request do
     before do
-      @article = Article.create(title: 'Title one', body: 'Body of article one')
+      @john = User.create(email: 'john@example.com', password: 'password')
+      @fred = User.create(email: 'fred@example.com', password: 'password')
+      @article = Article.create!(title: 'Title one', body: 'Body of article one', user: @john)
     end
 
+    describe 'GET /articless/:id/edit' do
+      context 'with non-signed in user' do
+        before { get "/articles/#{@article.id}/edit" }
+
+        it 'redirects to the sign in page' do
+          expect(response.status).to eq 302
+          flash_message = "You need to sign in or sign up before continuing."
+          expect(flash[:alert]).to eq flash_message
+        end
+      end
+
+      context 'with signed in user who is non owner' do
+        before do
+          login_as @fred
+          get "/articles/#{@article.id}/edit"
+        end
+
+        it 'redirects to the home page' do
+          expect(response.status).to eq 302
+          flash_message = 'You can only edit your own article.'
+          expect(flash[:alert]).to eq flash_message
+        end
+      end
+
+      context 'with signed in user as owner successful edit' do
+        before do
+          login_as @john
+          get "/articles/#{@article.id}/edit"
+        end
+
+        it 'successfully edits article' do
+          expect(response.status).to eq 200
+        end
+      end
+    end
+  
     describe 'GET /articles/:id' do
       context 'with existing article' do
         before { get "/articles/#{@article.id}"}


### PR DESCRIPTION
### What does this PR do?

#### Adds the next restrictions to articles controller:
- Index and show for all users
- Edit, Update and Destroy only by owners